### PR TITLE
Hardcoded Apk signing credential

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
 android {
     signingConfigs {
         create("release") {
-            storeFile = file("C:\\Users\\josem\\AndroidStudioProjects\\key store\\signing-key.jks")
-            storePassword = "Naruhodo26"
-            keyAlias = "Prod Testing"
-            keyPassword = "Naruhodo26"
+            storeFile = file(System.getenv("StoreFile"))
+            storePassword = System.getenv("StorePassword")
+            keyAlias = System.getenv("KeyAlias")
+            keyPassword = System.getenv("StorePassword")
         }
     }
     namespace = "com.joseg.dsavisualization"


### PR DESCRIPTION
**Overview**
Removed the hard coded Apk signing credential from the `build.gradle.kts` file. It's now being read from the OS environment variables. 